### PR TITLE
Update nfc.i

### DIFF
--- a/nfc.i
+++ b/nfc.i
@@ -838,7 +838,7 @@ supported_br : nfc_modulation_type array
 "
 %enddef
 %feature("autodoc", nfc_device_get_supported_baud_rate_doc) nfc_device_get_supported_baud_rate;
-int nfc_device_get_supported_baud_rate(nfc_device *pnd, const nfc_modulation_type nmt, const nfc_baud_rate **const supported_br);
+int nfc_device_get_supported_baud_rate(nfc_device *pnd, const nfc_mode mode, const nfc_modulation_type nmt, const nfc_baud_rate **const supported_br);
 
 
 


### PR DESCRIPTION
The prototype for `nfc_device_get_supported_baud_rate` did not match provided documentation.

Added `const nfc_mode mode` as second parameter to the function (as defined in libNFC >= 1.7.1).